### PR TITLE
Add space to SSH command to fix error when using -i option

### DIFF
--- a/rsync_time_machine.py
+++ b/rsync_time_machine.py
@@ -221,7 +221,7 @@ def parse_ssh(
         ssh_host = ssh["host"]
         auth = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
         id_rsa_opt = f"-i {id_rsa} " if id_rsa else ""
-        ssh_cmd = f"ssh -p {ssh_port} {'-i ' + id_rsa if id_rsa else ''}{auth}"
+        ssh_cmd = f"ssh -p {ssh_port} {id_rsa_opt}{auth}"
 
         ssh_src_folder_prefix = f"{auth}:" if ssh_src else ""
         ssh_dest_folder_prefix = f"{auth}:" if ssh_dest else ""

--- a/rsync_time_machine.py
+++ b/rsync_time_machine.py
@@ -220,7 +220,8 @@ def parse_ssh(
         ssh_user = ssh["user"] if ssh["user"] else ""
         ssh_host = ssh["host"]
         auth = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
-        ssh_cmd = f"ssh -p {ssh_port} {'-i ' + id_rsa if id_rsa else ''} {auth}"
+        id_rsa_opt = f"-i {id_rsa} " if id_rsa else ""
+        ssh_cmd = f"ssh -p {ssh_port} {'-i ' + id_rsa if id_rsa else ''}{auth}"
 
         ssh_src_folder_prefix = f"{auth}:" if ssh_src else ""
         ssh_dest_folder_prefix = f"{auth}:" if ssh_dest else ""

--- a/rsync_time_machine.py
+++ b/rsync_time_machine.py
@@ -220,7 +220,7 @@ def parse_ssh(
         ssh_user = ssh["user"] if ssh["user"] else ""
         ssh_host = ssh["host"]
         auth = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
-        ssh_cmd = f"ssh -p {ssh_port} {'-i ' + id_rsa if id_rsa else ''}{auth}"
+        ssh_cmd = f"ssh -p {ssh_port} {'-i ' + id_rsa if id_rsa else ''} {auth}"
 
         ssh_src_folder_prefix = f"{auth}:" if ssh_src else ""
         ssh_dest_folder_prefix = f"{auth}:" if ssh_dest else ""


### PR DESCRIPTION
Using the `-i` option to supply a SSH key fails with the error 'Safety check failed - the destination does not appear to be a backup folder or drive (marker file not found).' This seems to be because of a missing space in the SSH parsing code which means that the key address and the SSH address get munged together. This pull request simply adds a space between them.